### PR TITLE
Add f71, f86, update ISBN to component

### DIFF
--- a/src/api/independent-work/content-types/independent-work/schema.json
+++ b/src/api/independent-work/content-types/independent-work/schema.json
@@ -34,9 +34,9 @@
       },
       "type": "enumeration",
       "enum": [
-        "sbd",
-        "sm",
-        "s"
+        "Monografie",
+        "Mehrt. Mono (ÜO)",
+        "Band"
       ]
     },
     "f01": {
@@ -248,23 +248,6 @@
       },
       "type": "text"
     },
-    "endDate": {
-      "pluginOptions": {
-        "versions": {
-          "versioned": true
-        }
-      },
-      "type": "integer"
-    },
-    "f87_": {
-      "pluginOptions": {
-        "versions": {
-          "versioned": true
-        }
-      },
-      "type": "text",
-      "unique": false
-    },
     "f81": {
       "type": "component",
       "repeatable": true,
@@ -292,6 +275,40 @@
         }
       },
       "type": "text"
+    },
+    "f71k": {
+      "pluginOptions": {
+        "versions": {
+          "versioned": true
+        }
+      },
+      "type": "string"
+    },
+    "f86_": {
+      "pluginOptions": {
+        "versions": {
+          "versioned": true
+        }
+      },
+      "type": "string"
+    },
+    "f87": {
+      "type": "component",
+      "repeatable": true,
+      "pluginOptions": {
+        "versions": {
+          "versioned": true
+        }
+      },
+      "component": "rpb.isbn-component"
+    },
+    "endDate": {
+      "pluginOptions": {
+        "versions": {
+          "versioned": true
+        }
+      },
+      "type": "string"
     }
   }
 }

--- a/src/components/rpb/isbn-component.json
+++ b/src/components/rpb/isbn-component.json
@@ -1,0 +1,17 @@
+{
+  "collectionName": "components_rpb_isbn_components",
+  "info": {
+    "displayName": "ISBNComponent",
+    "icon": "book"
+  },
+  "options": {},
+  "attributes": {
+    "f87": {
+      "type": "string"
+    },
+    "korrekt": {
+      "type": "boolean",
+      "default": true
+    }
+  }
+}

--- a/src/components/rpb/isbn-component.json
+++ b/src/components/rpb/isbn-component.json
@@ -2,14 +2,15 @@
   "collectionName": "components_rpb_isbn_components",
   "info": {
     "displayName": "ISBNComponent",
-    "icon": "book"
+    "icon": "book",
+    "description": ""
   },
   "options": {},
   "attributes": {
-    "f87": {
+    "f87_": {
       "type": "string"
     },
-    "korrekt": {
+    "n87": {
       "type": "boolean",
       "default": true
     }


### PR DESCRIPTION
ref RPB-61

Folgendes wurde erledigt:

- Felder ergänzt:
  - Kart. Mat.: Math. Angaben (Maßstab) (=#71)
  - Sonstige Nummern (=#86)
 - ISBN angepasst: statt Textfeld  wiederholbare Komponente mit Boolean korrekt/falsch
 - Feld E-Jahr letzter Band (Ansetzungsform) (= `endDate`) zu Textfeld gemacht
 - Menschenlesbare Label anstatt `s`, `sm`, `sbd`i n Enumeration bei Satztyp (`f36_`)

Was bisher fehlt:
- entsprechende Anpassung der Fix für den Import Workflow, siehe dafür https://github.com/hbz/rpb/pull/45