### PR TITLE
Truncate lookup component labels if they are too long (RPB-161)

### DIFF
--- a/src/api/person/content-types/person/lifecycles.js
+++ b/src/api/person/content-types/person/lifecycles.js
@@ -28,9 +28,10 @@ module.exports = {
 
         const lookupFields = ["gndSubjectCategory", "placeOfActivity", "professionOrOccupation", "publication", "relatedPerson", "source"];
 
-        for (const field of lookupFields.filter((f) => result.hasOwnProperty(f))) {
+        for (const field of lookupFields.filter((f) => result && result.hasOwnProperty(f))) {
             for (const component of result[field]) {
                 component.label = await labelFor(component.value);
+                component.label = component.label.length > 250 ? component.label.substring(0, 249) + "..." : component.label;
             }
         }
 


### PR DESCRIPTION
To fit in `string` type (required to configure repeated components)

Also handle missing result (follow-up error when saving fails)

See https://jira.hbz-nrw.de/browse/RPB-161