### PR TITLE
Use new json:suggest format for title data lookups

### DIFF
--- a/src/plugins/lookup/admin/src/components/Autocomplete/index.js
+++ b/src/plugins/lookup/admin/src/components/Autocomplete/index.js
@@ -49,12 +49,19 @@ export default function Index({
       }
       const result = await response.json();
 
-      return result.map(r => {return {
-        name: r.label.replace(/, Stadt|, Kreisfreie Stadt|, große kreisangehörige Stadt/g, ""),
-        category: {id: "0", name: "cat-name-0"},
-        description: r.category,
-        id: path.endsWith("rpb") ? "http://rpb.lobid.org/" + lastSegment(r.id) : path.endsWith("rppd") ? "http://rppd.lobid.org/" + lastSegment(r.id) : r.id,
-        image: r.image || logo}});
+      return result.map(r => {
+        const delimiter = " | ";
+        const elements = r.label.split(delimiter);
+        const titleOnly = elements[0];
+        const details = elements.slice(1).join(delimiter);
+        return {
+          name: titleOnly.replace(/, Stadt|, Kreisfreie Stadt|, große kreisangehörige Stadt/g, ""),
+          category: {id: "0", name: "cat-name-0"},
+          description: `${details !== "" ? details + " | Typ: " : ""}${r.category}`,
+          id: path.endsWith("rpb") ? "http://rpb.lobid.org/" + lastSegment(r.id) : path.endsWith("rppd") ? "http://rppd.lobid.org/" + lastSegment(r.id) : r.id,
+          image: r.image || logo
+        }
+      });
 
     } catch (err) {
       setErr(err.message);

--- a/src/plugins/lookup/server/services/lookup.js
+++ b/src/plugins/lookup/server/services/lookup.js
@@ -26,7 +26,7 @@ module.exports = ({ strapi }) => ({
     try {
       const response = await axios(
         {
-          url: `http://lobid.org/resources/search?name=${prompt}&filter=${filter}&format=json:title&size=10`,
+          url: `http://lobid.org/resources/search?name=${prompt}&filter=${filter}&format=json:suggest&size=10`,
           method: 'GET',
         })
 
@@ -42,7 +42,7 @@ module.exports = ({ strapi }) => ({
     try {
       const response = await axios(
         {
-          url: `http://quaoar1.hbz-nrw.de:1990/resources/search?q=${prompt}&filter=${filter}&format=json:title&size=10`,
+          url: `http://quaoar1.hbz-nrw.de:1990/resources/search?q=${prompt}&filter=${filter}&format=json:suggest&size=10`,
           method: 'GET',
         })
 


### PR DESCRIPTION
And avoid truncation of details in lobid-based lookups.

See https://jira.hbz-nrw.de/browse/RPB-141 and [PR for lobid-resources](https://github.com/hbz/lobid-resources/pull/2080) (which is [deployed to test](https://test.lobid.org/resources/api#auto-complete)).

Deployed to Strapi test (e.g. field "Quelle der RPPD-Informationen" for persons):

https://rpb-cms-test.lobid.org/admin/content-manager/collectionType/api::person.person