### PR TITLE
Increase shared memory for postgresql container. Resolves #55

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -40,6 +40,7 @@ services:
     restart: unless-stopped
     env_file: .env
     image: postgres:12.0-alpine
+    shm_size: '1gb'
     environment:
       POSTGRES_USER: ${DATABASE_USERNAME}
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
     restart: unless-stopped
     env_file: .env
     image: postgres:12.0-alpine
+    shm_size: '1gb'
     environment:
       POSTGRES_USER: ${DATABASE_USERNAME}
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD}


### PR DESCRIPTION
Default is 64MB. Increase to 1gb. The host machine has 8gb available.

You will need to restart the container for this to take effect.