### PR TITLE
Send indexing PUT to BiblioVino as well for un-caching

### DIFF
--- a/src/api/indexHelper.js
+++ b/src/api/indexHelper.js
@@ -3,13 +3,25 @@ const fetch = require("node-fetch");
 module.exports = {
     index: async (event) => {
         const secret = strapi.config.get('admin.auth.secret', '');
-        const url = `http://test.rpb.lobid.org/${event.result.rpbId}?secret=${secret}`; // http://host.docker.internal:9000
-        const response = await fetch(url, {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(event.result),
-        });
-        console.log(`Indexing response for ${event.result.rpbId} to ${url}:`,
-            response.status, response.statusText, await response.text());
+        for(const url of urls(event.result.inCollection)) {
+            const response = await fetch(`${url}/${event.result.rpbId}?secret=${secret}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(event.result),
+            });
+            console.log(`Indexing response for ${event.result.rpbId} to ${url}:`,
+                response.status, response.statusText, await response.text());
+        }
     }
+}
+
+const urls = (inCollection) => {
+    const result = [];
+    if(inCollection.includes("RPB")) {
+        result.push("http://test.rpb.lobid.org"); // http://host.docker.internal:9000
+    }
+    if(inCollection.includes("BiblioVino")) {
+        result.push("http://test.wein.lobid.org"); // http://host.docker.internal:9000
+    }
+    return result;
 }


### PR DESCRIPTION
For global caching in BiblioVino, it needs to know about updates (un-cache indexed entry to allow seeing the update in the UI)

See https://github.com/hbz/rpb/pull/106