### PR TITLE
Raise postgres statement_timeout

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -55,7 +55,7 @@ services:
       POSTGRES_USER: ${DATABASE_USERNAME}
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
       POSTGRES_DB: ${DATABASE_NAME}
-    command: postgres -c statement_timeout=1min
+    command: postgres -c statement_timeout=10min
     volumes:
       #- strapi-rpb-data:/var/lib/postgresql/data/ #using a volume
       - ./data/postgresql/data:/var/lib/postgresql/data/ # if you want to use a bind folder

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -55,7 +55,7 @@ services:
       POSTGRES_USER: ${DATABASE_USERNAME}
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
       POSTGRES_DB: ${DATABASE_NAME}
-    command: postgres -c statement_timeout=1min
+    command: postgres -c statement_timeout=10min
     volumes:
       #- strapi-rpb-data:/var/lib/postgresql/data/ #using a volume
       - ./data/postgresql/data:/var/lib/postgresql/data/ # if you want to use a bind folder


### PR DESCRIPTION
This task 

`docker compose exec strapi-rpb strapi config:dump -f config.json-`date +%u` > /dev/null`

running via cron  sometimes fails due to statement timeout:

> error: alter table "public"."components_rpb_subject-component-lists_components" add constraint "components_rpb_subject-component-lists_unique" unique ("entity_id", "component_id", "field", "component_type") - canceling statement due to statement timeout
>     at Parser.parseErrorMessage (/opt/node_modules/pg-protocol/dist/parser.js:283:98)
>     at Parser.handlePacket (/opt/node_modules/pg-protocol/dist/parser.js:122:29)
>     at Parser.parse (/opt/node_modules/pg-protocol/dist/parser.js:35:38)
>     at Socket.<anonymous> (/opt/node_modules/pg-protocol/dist/index.js:11:42)
>     at Socket.emit (node:events:513:28)
>     at Socket.emit (node:domain:489:12)
>     at addChunk (node:internal/streams/readable:315:12)
>     at readableAddChunk (node:internal/streams/readable:289:9)
>     at Socket.Readable.push (node:internal/streams/readable:228:10)
>     at TCP.onStreamRead (node:internal/stream_base_commons:190:23) {
>   length: 109,
>   severity: 'ERROR',
>   code: '57014',
>   detail: undefined,
>   hint: undefined,
>   position: undefined,
>   internalPosition: undefined,
>   internalQuery: undefined,
>   where: undefined,
>   schema: undefined,
>   table: undefined,
>   column: undefined,
>   dataType: undefined,
>   constraint: undefined,
>   file: 'postgres.c',
>   line: '3094',
>   routine: 'ProcessInterrupts'
> }

Not sure why strapi needs to do an `alter table` statement here. 

Raise timeout from 1min up to 10min. **This is already applied von test.** Let's see if this helps. @fsteeg  