### PR TITLE
Load record via entity service API in `afterUpdate` hook (RPB-179)

### DIFF
--- a/src/api/article/content-types/article/lifecycles.js
+++ b/src/api/article/content-types/article/lifecycles.js
@@ -47,6 +47,7 @@ module.exports = {
         }
     },
     async afterUpdate(event) {
+        event.result = await strapi.entityService.findOne(type, event.result.id, { populate: populateAll });
         backupHelper.saveToDisk(event);
         indexHelper.index(event);
     },

--- a/src/api/external-record/content-types/external-record/lifecycles.js
+++ b/src/api/external-record/content-types/external-record/lifecycles.js
@@ -32,6 +32,7 @@ module.exports = {
         }
     },
     async afterUpdate(event) {
+        event.result = await strapi.entityService.findOne(type, event.result.id, { populate: populateAll });
         backupHelper.saveToDisk(event);
         indexHelper.index(event);
     },

--- a/src/api/independent-work/content-types/independent-work/lifecycles.js
+++ b/src/api/independent-work/content-types/independent-work/lifecycles.js
@@ -48,7 +48,8 @@ module.exports = {
             backupHelper.saveToDisk({ model: { collectionName: event.model.collectionName }, result: entriesWithRpbId[0] });
         }
     },
-    afterUpdate(event) {
+    async afterUpdate(event) {
+        event.result = await strapi.entityService.findOne(type, event.result.id, { populate: populateAll });
         backupHelper.saveToDisk(event);
         indexHelper.index(event);
     },


### PR DESCRIPTION
See https://jira.hbz-nrw.de/browse/RPB-179

When triggered in an update of a single field, the `event.result` passed to the `afterUpdate` hook contains no component data. To save and index the complete record, we get it via `entityService`.